### PR TITLE
add option to clear to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Like other console clearing modules but it works on my machine.
 var clear = require('clear-console');
 clear()
 ```
+## `toStart` option
+On Mac OS X terminal, this option clears to start (just like pressing &#8984;K):
+```
+var clear = require('clear-console');
+clear({toStart: true})
+```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-module.exports = function () {
+module.exports = function (options) {
   process.stdout.write('\u001b[2J')
   process.stdout.write('\u001b[1;1H')
+  if (options && options.toStart) process.stdout.write('\u001b[3J')
 }


### PR DESCRIPTION
now if you call `clear({toStart: true})` it will clear to start (on my mac terminal at least), so that you can't scroll back to the cleared output.  When I'm running tests, linting, etc. in watch mode, I find it helpful to be able to nuke the old output so I can navigate through the latest errors as quickly as possible.